### PR TITLE
Rustup to rustc 1.92.0-nightly (3d8c1c1fc 2025-10-06)

### DIFF
--- a/clipper_inject/Cargo.toml
+++ b/clipper_inject/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 edition.workspace = true
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/clipper_inject/src/lib.rs
+++ b/clipper_inject/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(fn_ptr_trait)]
-#![feature(lazy_cell)]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
 // SPDX-FileCopyrightText: 2023 Jade Lovelace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 [toolchain]
-channel = "nightly-2023-07-24"
+channel = "nightly-2025-10-07"
 profile = "default"

--- a/rustls-intercept/rustls/src/lib.rs
+++ b/rustls-intercept/rustls/src/lib.rs
@@ -268,7 +268,7 @@
     unreachable_pub,
     unused_import_braces,
     unused_extern_crates,
-    unused_qualifications
+    //unused_qualifications
 )]
 // Relax these clippy lints:
 // - ptr_arg: this triggers on references to type aliases that are Vec


### PR DESCRIPTION
There are a bunch of warnings during compilation, but it compiles and runs fine.